### PR TITLE
Remove Passport from Books project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
   - [Nest Permissions Seed](https://github.com/EndyKaufman/nest-permissions-seed) - A simple application demonstrating the basic usage of permissions with NestJS.
   - [Angular NestJS Rendering](https://github.com/Innovic-io/angular-nestjs-rendering) - Angular 5+ server side rendering using NestJS.
   - [Angular Contact Manager App](https://github.com/Abdallah-khalil/ContactManagerApp) - A Contact Manager App using Angular, NestJS, Mongoose, Passport, JWT.
-  - [Books Library API](https://github.com/Abdallah-khalil/Books-Library-API) - A restful API with NestJS, mongoose, Passport and JWT.
+  - [Books Library API](https://github.com/Abdallah-khalil/Books-Library-API) - A restful API with NestJS and mongoose.
   - [Passport Auth NestJS](https://github.com/Abdallah-khalil/NodeJsWithPassport) - Passport strategies and oauth integration built with NestJS.
   - [NestJS Auth0](https://github.com/jajaperson/nestjs-auth0) - An example NestJS application that uses Auth0 via Passport for authentication.
   - [Lynx](https://github.com/mentos1386/lynx) - Opinionated Framework built on top of NestJS and TypeORM.


### PR DESCRIPTION
I wonder if Passport was erroneously included in other project descriptions.

## Resource type _(required)_

- [ ] GitHub Repository:
    - [ ] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [ ] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [x] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

_Brief description of the resource you are adding._

## Link _(required)_

_Paste link here._

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
