### PR TITLE
chore: remove nestjs london meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@
 
 ## Meetups
 
-- [NestJS London](https://www.meetup.com/NestJS-London/)
+None at the moment. Why not create a meetup and make a PR?
 
 ## Contribute
 


### PR DESCRIPTION
The NestJS London meetup link is dead. This PR removes it from the README