### PR TITLE
docs(): add link to nestjs-cls

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
   - [Nest Queue](https://github.com/owl1n/nest-queue) - Easy queue management based on Redis for your application.
   - [Nest Toolbox](https://github.com/lupu60/nestjs-toolbox) - The repository contains a suite of components and modules for NestJS.
   - [Nest Multer Extended](https://github.com/jeffminsungkim/nestjs-multer-extended) - Extended MulterModule for NestJS framework with flexible Amazon S3 upload and helpful features.
+  - [Nest CLS](https://github.com/Papooch/nestjs-cls) - A continuation-local storage module compatible with NestJS's dependency injection.
 - State Management
   - [Ngrx Nest](https://github.com/derekkite/ngrx-nest) - Ngrx/store and ngrx/effects on the server using the nest framework.
 - Code Style

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
   - [Nest Queue](https://github.com/owl1n/nest-queue) - Easy queue management based on Redis for your application.
   - [Nest Toolbox](https://github.com/lupu60/nestjs-toolbox) - The repository contains a suite of components and modules for NestJS.
   - [Nest Multer Extended](https://github.com/jeffminsungkim/nestjs-multer-extended) - Extended MulterModule for NestJS framework with flexible Amazon S3 upload and helpful features.
-  - [Nest CLS](https://github.com/Papooch/nestjs-cls) - A continuation-local storage module compatible with NestJS's dependency injection.
+  - [Nest CLS](https://github.com/Papooch/nestjs-cls) - A continuation-local storage module for Nest (using `async_hooks`)
 - State Management
   - [Ngrx Nest](https://github.com/derekkite/ngrx-nest) - Ngrx/store and ngrx/effects on the server using the nest framework.
 - Code Style


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

A continuation-local storage module compatible with NestJS's dependency injection.
Some common use cases of CLS include:
* Request ID tracing for logging purposes
* Making the Tenant ID available everywhere in multi-tenant apps
* Globally setting the authentication level for the request

Since the package is becoming increasingly popular, I thought I'd add it to the list.
I'm not sure whether I put it in the right category, so please be the judge.

## Link _(required)_

https://github.com/Papooch/nestjs-cls
