### PR TITLE
Add github workflow 'links checker'

### DIFF
--- a/.github/workflows/links_checker.yml
+++ b/.github/workflows/links_checker.yml
@@ -1,0 +1,85 @@
+name: Links Checker
+
+on:
+  ## Allow triggering this workflow manually via GitHub CLI/web
+  workflow_dispatch:
+
+  ## Run this workflow automatically every month
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  linkChecker:
+    name: Check links and create automated issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      REPORT_FILE: links-report
+    steps:
+      ## Check out code using Git
+      - uses: actions/checkout@v2
+
+      - name: Check all links at README.md file
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.2.0
+        with:
+          format: markdown
+          output: ${{ env.REPORT_FILE }}
+          fail: false
+          ## Allow pages replying with 200 (Ok), 204 (No Content), 400 (Bad Request)
+          ## 206 (Partial Content) in at most 20 seconds with HTML content.
+          args: >-
+            --verbose
+            --accept 200,204,206,400
+            --headers "accept=text/html"
+            --timeout 20
+            --no-progress
+            README.md
+        env:
+          ## Avoid rate limiting when checking github.com links
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lychee's exit code
+        ## https://github.com/lycheeverse/lychee#exit-codes
+        run: echo Lychee exit with ${{ steps.lychee.outputs.exit_code }}
+
+      - name: Find the last report issue open
+        uses: micalevisk/last-issue-action@v1
+        id: last_issue
+        with:
+          state: open
+          labels: |
+            report
+            automated issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create an issue from report file
+        if: ${{ steps.last_issue.outputs.has_found == 'false' }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.REPORT_FILE }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Update the last report open issue open
+        if: ${{ steps.last_issue.outputs.has_found == 'true' }}
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link checker report
+          content-filepath: ${{ env.REPORT_FILE }}
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}
+          labels: |
+            report
+            automated issue
+
+      - name: Close the last report open issue
+        if: >-
+          steps.last_issue.outputs.has_found == 'true' &&
+          steps.lychee.outputs.exit_code == 0
+        uses: peter-evans/close-issue@v1
+        with:
+          issue-number: ${{ steps.last_issue.outputs.issue_number }}


### PR DESCRIPTION
My first attempt on use https://github.com/lycheeverse/lychee-action to automatically create an issue reporting all bad links. Here's an example of that issue: https://github.com/micalevisk/awesome-nestjs/issues/8 This issue will be created only if there's some bad link on `README.md` file.

Besides that, this workflow will find the last open issue with the label 'report' and update it instead of creating a new one. Or will close it if there's no bad link found.

Not sure if you guys are looking for something like this, tho.