### PR TITLE
docs: add mockingbird library under 'testing' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@
     - [Testing Nestjs](https://github.com/jmcdo29/testing-nestjs ) - A repository to show off to the community methods of testing NestJS including Unit Tests, Integration Tests, E2E Tests, pipes, filters, interceptors, GraphQL, Mongo, TypeORM, and more!
   - Utilities
     - [GoLevelUp utilities for Jest](https://www.npmjs.com/package/@golevelup/ts-jest) - Utilities for making testing NestJS applications easier. Currently supports Jest.
+    - [Mockingbird](https://www.npmjs.com/package/mockingbird) - A library to create typed tests fixtures/mocks using decorators and built-in faker support
 
 ## Integrations
 


### PR DESCRIPTION
Add a new library called Mockingbird under "Testing" section.

## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

Mockingbird is a nice library to create typed mocks and fixtures easily with decorators

## Link _(required)_

NPM: https://npmjs.com/package/mockingbird
GitHub: https://github.com/omermorad/mockingbird

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
