### PR TITLE
add Ogma logger repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@
 
 - [Nest Winston](https://github.com/gremo/nest-winston) - Winston module for NestJS.
 - [Nest Pino](https://github.com/iamolegga/nestjs-pino) - Pino module for NestJS Log with request context in any place.
+- [Ogma](https://github.com/jmcdo29/ogma) - A monorepo for the Ogma logger and related packages.
 
 #### Monitoring
 


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

## Description _(required)_

> Ogma is a no-nonsense logger developed to make logging simple, and easy to read in development, while also having a powerful JSON form when it comes to production level logs, to make it easier to parse and consume by external services. This monorepo has all of the code for the base logger, the binary to rehydrate the JSON logs, and the NestJS Module along with supported plugins for the module's interceptor.

## Link _(required)_

https://github.com/jmcdo29/ogma

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
