### PR TITLE
chore(docs): add pactjs for nestjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 
 - [GoLevelUp utilities for Jest](https://www.npmjs.com/package/@golevelup/ts-jest) - Utilities for making testing NestJS applications easier. Currently supports Jest.
 - [Mockingbird](https://www.npmjs.com/package/mockingbird) - A library to create typed tests fixtures/mocks using decorators and built-in faker support
+- [NestJS + Pact](https://www.npmjs.com/package/nestjs-pact) - Injectable Pact.js Consumer/Provider for NestJS
 
 ## Integrations
 


### PR DESCRIPTION
Add PactJS for NestJS package

## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

I'm adding a link to `nestjs-pact` which is a project that connects pact with NestJS with dynamic modules.


## Link _(required)_

https://npmjs.com/package/nestjs-pact

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
