### PR TITLE
add nest-sdk-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@
 - ![](https://img.shields.io/github/stars/nestjs/nest-cli.svg?style=flat-square) [CLI](https://github.com/nestjs/nest-cli) - CLI tool for NestJS applications.
 - ![](https://img.shields.io/github/stars/ashinzekene/generator-nestjs-app.svg?style=flat-square) [Yeoman Generator](https://github.com/ashinzekene/generator-nestjs-app) - A yeoman generator for NestJS apps.
 - ![](https://img.shields.io/github/stars/Pop-Code/nestjs-console.svg?style=flat-square) [NestJS Console](https://github.com/Pop-Code/nestjs-console) - A NestJS module that provide a cli to application.
+- ![](https://img.shields.io/github/stars/LoneStone/nest-sdk-generator.svg?style=flat-square) [Typescript SDK Generator](https://github.com/lonestone/nest-sdk-generator) - A command-line utility to generate a fully typed SDK from a Nest.js REST API
 
 ## Meetups
 


### PR DESCRIPTION
## Resource type

- [X] GitHub Repository:
    - [x] I confirm that the GitHub repository has more than **10 stars**.
    - [X] The repository is not archived.

## Description

A command-line tool to generate strongly-typed TypeScript SDKs from NestJS REST API servers.

## Link

https://github.com/lonestone/nest-sdk-generator

## Rules

- [X] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [X] **Node.js**: It's not nodejs, node, and other variants.
