### PR TITLE
docs: add nestjs-tile38

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@
 - ![](https://img.shields.io/github/stars/kpfromer/nestjs-typegoose.svg?style=flat-square) [`nestjs-typegoose`](https://github.com/kpfromer/nestjs-typegoose) - A [Typegoose](https://github.com/typegoose/typegoose) module for Nest framework.
 - ![](https://img.shields.io/github/stars/mikro-orm/nestjs.svg?style=flat-square) [`@mikro-orm/nestjs`](https://github.com/mikro-orm/nestjs) - A [MikroORM](https://mikro-orm.io/) module for Nest Framework.
 - [Nest Prisma](https://www.prisma.io/nestjs) - A Fully Type-Safe ORM for [NestJS](https://docs.nestjs.com/recipes/prisma).
+- ![](https://img.shields.io/github/stars/hyperloris/nestjs-tile38.svg?style=flat-square) [`nestjs-tile38`](https://github.com/hyperloris/nestjs-tile38) - A [Tile38](https://tile38.com) module for Nest framework.
 
 #### GraphQL
 


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

This is a [Tile38](https://tile38.com) module for [Nest](https://github.com/nestjs/nest). The package is based on [Tile38-ts](https://github.com/tiermobility/tile38-ts), which is the best TypeScript library for interacting with the Tile38 database.

## Link _(required)_

- [GitHub](https://github.com/hyperloris/nestjs-tile38)
- [npm](https://www.npmjs.com/package/nestjs-tile38)

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
