### PR TITLE
Add ocoda/event-sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@
 
 - ![](https://img.shields.io/github/stars/PrestaShopCorp/nestjs-geteventstore.svg?style=flat-square) [`nestjs-geteventstore` by PrestaShopCorp](https://github.com/PrestaShopCorp/nestjs-geteventstore) - An evenstore.org module for NestJS CQRS with Projects and Subscriptions. Supports Eventstore 21.10.0+
 - ![](https://img.shields.io/github/stars/juicycleff/nestjs-event-store.svg?style=flat-square) [`@juicycleff/nestjs-event-store`](https://github.com/juicycleff/nestjs-event-store) - An evenstore.org module for NestJS CQRS with adapter support to persist lastcheckpoint for Catchup subscription.
+- ![](https://img.shields.io/github/stars/ocoda/event-sourcing.svg?style=flat-square) [`@ocoda/event-sourcing`](https://github.com/ocoda/event-sourcing) - An Event Sourcing and CQRS module for NestJS with support for MongoDB and DynamoDB.
 
 #### Payment Gateways
 


### PR DESCRIPTION
## Resource type

- [x] GitHub Repository:
    - [X] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [X] **(Required)** The repository is not archived.

## Description

`ocoda/event-sourcing` is an event-sourcing and CQRS module for NestJS, providing event storage for multiple database providers and the possibility to register custom event-publishers.
For now MongoDB and DynamoDB are supported.

## Link

https://github.com/ocoda/event-sourcing

## Rules

- [X] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [X] **Node.js**: It's not nodejs, node, and other variants.
