### PR TITLE
Adding Graceful shutdown example for Microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [TypeScript Clean Architecture](https://github.com/pvarentsov/typescript-clean-architecture) - Clean Architecture based application with NestJS, PostgreSQL and TypeORM.
 - [NestJS Apps Collection](https://github.com/Tony133/nestjs-apps-collection) - Collection example apps with NestJS and Typeorm, Mongodb, PostgreSQL, GraphQL, Mercurius, etc. for the NestJS community
 - [Lyricstify](https://github.com/lyricstify/lyricstify) - Command line based application to show synchronized Spotify lyrics in your terminal. Built with Node, TypeScript, Nest Commander & RxJs.
+- [NestJs RabbitMQ Transporter with the graceful shutdown](https://github.com/pasalino/nestjs-rabbitmq-transporter-graceful-shutdown) - An implementation example of graceful shutdown for microservices based on RabbitMQ message broker.
 
 #### Boilerplate
 
@@ -159,7 +160,6 @@
 - [Necord/Toolkit](https://github.com/necordjs/toolkit) - Toolkit is an open-source bot for searching and sending documentation, built with Necord.
 - [Undb](https://github.com/undb-xyz/undb) - Undb is a no-code database based on Svelte-kit and SQLite.
 
-
 ## Components & Libraries
 
 #### Utilities
@@ -181,7 +181,6 @@
 - ![](https://img.shields.io/github/stars/samchon/nestia.svg?style=flat-square) [`@nestia/core`](https://github.com/samchon/nestia): 20,000x times faster validation and 200x faster JSON serialization decorators using `typia`. Enable to utilize pure TypeScript interface type as DTO, and overall server performance improved by about 30x times.
 - ![](https://img.shields.io/github/stars/samchon/nestia.svg?style=flat-square) [`@nestia/migrate`](https://github.com/samchon/nestia): Migration program generating NestJS project from `swagger.json` file. Also possible to generate SDK (collection of `fetch` functions with type definitions) and Mockup Simulator (backend server simulator embedded in SDK) from `swagger.json` file through `@nestia/sdk`
 - ![](https://img.shields.io/github/stars/rsinger86/dto-classes.svg?style=flat-square) [`dto-classes`](https://github.com/rsinger86/dto-classes): Developer-friendly parsing, validation & serialization. Pipes auto-parse via type declarations. Uses properties for field schemas, not decorators.
-
 
 #### Code Style
 


### PR DESCRIPTION
## Resource type

- [X] GitHub Repository:
    - [X] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [X] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description

A Custom Transporter for NestJS Microservices based on RabbitMQ broker with graceful shutdown.

In the current NestJS RabbitMQ Microservice transport implementation, the framework does execute the message handle but doesn’t take care of it in case of the server shutdown. In case of a shutdown, the handler interrupts its execution without waiting for its finish.
To achieve the graceful shutdown without losing any execution, the custom implementation overrides the handleMessage method by adding a counter of the current executions. This counter allows the Custom Transporter to wait for all handlers before closing Rabbit Channel and Connection.

## Link 

https://github.com/pasalino/nestjs-rabbitmq-transporter-graceful-shutdown

## Rules 

- [X] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [X] **Node.js**: It's not nodejs, node, and other variants.
