### PR TITLE
add Cache section & omacahe repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@
 
 #### Cache
 
-- [](https://img.shields.io/github/stars/nest-modules/ioredis.svg?style=flat-square) [`nestjs-omacache`](https://github.com/BJS-kr/nestjs-omacache) - A simple, flexible and powerful cache decorator factory for NestJS framework
+- [](https://img.shields.io/github/stars/BJS-kr/nestjs-omacache.svg?style=flat-square) [`nestjs-omacache`](https://github.com/BJS-kr/nestjs-omacache) - A simple, flexible and powerful cache decorator factory for NestJS framework
 
 #### Redis
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@
 
 - [`@nestjs/websockets`](https://docs.nestjs.com/websockets/gateways)
 
+#### Cache
+
+- [](https://img.shields.io/github/stars/nest-modules/ioredis.svg?style=flat-square) [`nestjs-omacache`](https://github.com/BJS-kr/nestjs-omacache) - A simple, flexible and powerful cache decorator factory for NestJS framework
+
 #### Redis
 
 - ![](https://img.shields.io/github/stars/nest-modules/ioredis.svg?style=flat-square) [`@nestjs-modules/ioredis`](https://github.com/nest-modules/ioredis) - A ioredis module for Nest framework.


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

This package provides cache decorator factory
It can be used from any storage, so I added Cache section

I posted [article on medium](https://medium.com/p/d71e3140f5e4) too
I will publish this project on npm 25/02/2024(KST)

## Link _(required)_

https://github.com/BJS-kr/nestjs-omacache

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
