### PR TITLE
add Ory integration libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@
 
 - ![](https://img.shields.io/github/stars/cdiaz/nestjs-auth0.svg?style=flat-square) [Nest + Auth0](https://github.com/cdiaz/nestjs-auth0) - NestJS Framework web application with Auth0.
 - ![](https://img.shields.io/github/stars/tfarras/nestjs-firebase-auth.svg?style=flat-square) [`@tfarras/nestjs-firebase-auth`](https://github.com/tfarras/nestjs-firebase-auth) - NestJS Passport Strategy for Firebase Auth using Firebase Admin SDK
+- ![](https://img.shields.io/github/stars/getlarge/nestjs-ory-integration.svg?style=flat-square) [`@getlarge/nestjs-ory-integration`](https://github.com/getlarge/nestjs-ory-integration) - Suite of libraries to integrate the Ory stack (Hydra, Keto, Kratos) to secure your NestJS applications.
 
 #### Databases
 


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

This mono repository contains several packages to simplify the integration of Ory Kratos, Keto, and Hydra 

The following libraries wrap up Ory services API and make them available via dedicated, dynamic modules:
- [keto-client-wrapper](https://github.com/getlarge/nestjs-ory-integration/blob/main/packages/keto-client-wrapper/README.md)
- [kratos-client-wrapper](https://github.com/getlarge/nestjs-ory-integration/blob/main/packages/kratos-client-wrapper/README.md)
- [hydra-client-wrapper](https://github.com/getlarge/nestjs-ory-integration/blob/main/packages/hydra-client-wrapper/README.md)

Each of those libraries has two modules and contains a Guard to make route protection straightforward.

## Link _(required)_

https://github.com/getlarge/nestjs-ory-integration/tree/main

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
