### PR TITLE
Rename nestjs-metrics-client to nestjs-metrics-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@
 - ![](https://img.shields.io/github/stars/SocketSomeone/nestjs-hot-shots.svg?style=flat-square) [`nestjs-hot-shots`](https://github.com/SocketSomeone/nestjs-hot-shots) - Hot-shots Module for NestJS. A Node.js client for Etsy's StatsD server, Datadog's DogStatsD server, and InfluxDB's Telegraf StatsD server.
 - ![](https://img.shields.io/github/stars/willsoto/nestjs-prometheus.svg?style=flat-square) [`nestjs-prometheus`](https://github.com/willsoto/nestjs-prometheus) - NestJS module for Prometheus.
 - ![](https://img.shields.io/github/stars/apitally/apitally-js.svg?style=flat-square) [`apitally`](https://github.com/apitally/apitally-js) - Client library for [Apitally](https://apitally.io/nestjs), a simple API monitoring & analytics tool with alerting for NestJS.
-- ![](https://img.shields.io/github/stars/netanelavr/nestjs-metrics-client.svg?style=flat-square) [`nestjs-metrics-client`](https://github.com/netanelavr/nestjs-metrics-client) - A zero-dependency-injection global metrics reporter for NestJS.
+- ![](https://img.shields.io/github/stars/netanelavr/nestjs-metrics-reporter.svg?style=flat-square) [`nestjs-metrics-reporter`](https://github.com/netanelavr/nestjs-metrics-reporter) - A zero-dependency-injection global metrics reporter for NestJS.
 
 #### Internationalization (i18n)
 


### PR DESCRIPTION
Following this PR - https://github.com/nestjs/awesome-nestjs/pull/311
updating with the new package name

## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [x] Tutorial.
- [ ] Meetups.
- [x] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

 A zero-dependency-injection alternative to Prometheus metrics solutions for NestJS.
Effortlessly report metrics from anywhere in your codebase without complex setup or dependency injection

## Link _(required)_

[_Paste link here._](https://github.com/netanelavr/nestjs-metrics-client)

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
