### PR TITLE
add articles on how to use generic type args with `@nestjs/swagger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@
 - YouTube playlist by Codeforges TM: [Angular + NestJs Tutorials](https://www.youtube.com/playlist?list=PLq1kZ5GbKd4qyDcK3IHGSi4FDAL6fRZeL) - Building a full-stack blog with NestJS, Angular and Angular Material.
 - Udemy free course: [The complete NestJS developer. Enterprise Node.js framework](https://www.udemy.com/course/the-complete-nestjs-developer-enterprise-nodejs-framework/) - The complete guide for developers how to create enterprise ready applications using NestJS framework.
 - [NestJS and Project Structure - What to Do?](https://dev.to/smolinari/nestjs-and-project-structure-what-to-do-1223) - An article to show you how to structure your application with NestJS
+- For `@nestjs/swagger` with generic types:
+    + [How to generate generic DTOs with NestJs and Swagger](https://www.inextenso.dev/how-to-generate-generic-dtos-with-nestjs-and-swagger)
+    + [How to generate Generics DTOs with nestjs/swagger](https://aalonso.dev/blog/2021/how-to-generate-generics-dtos-with-nestjsswagger-422g)
 
 #### Examples
 


### PR DESCRIPTION
## Resource type _(required)_

- [ ] GitHub Repository:
    - [ ] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [ ] **(Required)** The repository is not archived.
- [ ] Video.
- [x] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

two ways on using `@nestjs/swagger` with generic type args

## Link _(required)_

- https://www.inextenso.dev/how-to-generate-generic-dtos-with-nestjs-and-swagger
- https://aalonso.dev/blog/2021/how-to-generate-generics-dtos-with-nestjsswagger-422g

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
