### PR TITLE
Add Manifest as open source project using NestJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [Undb](https://github.com/undb-xyz/undb) - Undb is a no-code database based on Svelte-kit and SQLite.
 - [Eicrud](https://github.com/eicrud/eicrud) - An opinionated framework that extends NestJS with CRUD services, user management commands, and authorization controls.
 - [apitable](https://github.com/apitable/apitable) - APITable, an API-oriented low-code platform for building collaborative apps and better than all other Airtable open-source alternatives.
+- [Manifest](https://manifest.build) - 1-file micro backend in YAML.
 
 ## Components & Libraries
 


### PR DESCRIPTION
Adding [Manifest.build](https://manifest.build/) backend as it is made with NestJS: https://github.com/mnfst/manifest

## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

> If your contribution is NOT a GitHub repository, then you can skip the next titles, except "Rules".

## Description _(required)_

Adding [Manifest.build](https://manifest.build/) backend as it is made with NestJS

## Link _(required)_

https://manifest/build

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
