### PR TITLE
Add dicoshot-nest

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 - ![](https://img.shields.io/github/stars/Akronae/nestjs-openapi-validation?style=flat-square) [`nestjs-openapi-validation`](https://github.com/Akronae/nestjs-openapi-validation) - Validate NestJS DTOs with Zod using TypeScript/OpenAPI spec.
 - ![](https://img.shields.io/github/stars/abinnovision/nestjs-commons.svg?style=flat-square) [`@abinnovision/nestjs-configx`](https://github.com/abinnovision/nestjs-commons/tree/main/packages/configx) - Simple configuration management for NestJS, supporting [Standard Schema](https://standardschema.dev/).
 - ![](https://img.shields.io/github/stars/rejifald/StitchAPI.svg?style=flat-square) [`@stitchapi/nest`](https://github.com/rejifald/StitchAPI/tree/main/packages/nest) - Injectable, typed and schema-validated HTTP clients with streaming, retries, throttling and caching, plus Logger and ConfigService bridges, an exception filter and an SSE bridge.
+- ![](https://img.shields.io/github/stars/DicoShot/dicoshot-nest.svg?style=flat-square) [`dicoshot-nest`](https://github.com/DicoShot/dicoshot-nest) - Discord webhook notifications for NestJS app lifecycle events.
 
 #### Code Style
 


### PR DESCRIPTION
Adds dicoshot-nest, a lightweight NestJS package that sends Discord webhook notifications on app start/shutdown lifecycle events.

npm: https://www.npmjs.com/package/dicoshot-nest